### PR TITLE
Hardcode the port

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ LANGUAGES = {
     'Português': 'pt',
 }
 
-PORT = int(os.environ.get('PORT', '8443'))
+PORT = 8443
 TOKEN = os.environ.get('TOKEN', '')
 
 def start(update: Update, _: CallbackContext) -> int:


### PR DESCRIPTION
Unfortunately Heroku is ignoring `PORT` as an environmental variable.
Trying to hardcode it.

<img width="1231" alt="image" src="https://user-images.githubusercontent.com/15848876/139559733-4370f8b2-3e89-42e2-837a-064ef24f79a8.png">
