### PR TITLE
Updated version

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ LANGUAGES = {
     'Português': 'pt',
 }
 
-PORT = 8443
+PORT = int(os.environ.get('PORT', '8443'))
 TOKEN = os.environ.get('TOKEN', '')
 
 def start(update: Update, _: CallbackContext) -> int:
@@ -72,8 +72,11 @@ def main():
     updater.dispatcher.add_handler(conv_handler)
 
     logger.info(f"Starting webhook on PORT {PORT}")
-    updater.start_webhook(listen="0.0.0.0", port=PORT, url_path=TOKEN)
-    updater.bot.setWebhook(f"https://joke-api-bot.herokuapp.com/{TOKEN}")
+    updater.start_webhook(
+        listen="0.0.0.0",
+        port=PORT,
+        url_path=TOKEN,
+        webhook_url=f"https://joke-api-bot.herokuapp.com/{TOKEN}")
 
     updater.idle()
 


### PR DESCRIPTION
Apparently, PTB library has changed their API.

[Previously](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Webhooks/8a69a3d0ead8382cfdc878c25ec11eb8ceb3eb58):
```py
import os

TOKEN = "TOKEN"
PORT = int(os.environ.get('PORT', '5000'))
updater = Updater(TOKEN)
# add handlers
updater.start_webhook(listen="0.0.0.0",
                      port=PORT,
                      url_path=TOKEN)
updater.bot.setWebhook("https://<appname>.herokuapp.com/" + TOKEN)
updater.idle()
```

[Now](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Webhooks/03d096476e41b237e50fc7214f496ab350e8c68c):
```py
import os

TOKEN = "TOKEN"
PORT = int(os.environ.get('PORT', '8443'))
updater = Updater(TOKEN)
# add handlers
updater.start_webhook(listen="0.0.0.0",
                      port=PORT,
                      url_path=TOKEN,
                      webhook_url="https://<appname>.herokuapp.com/" + TOKEN)
updater.idle()
```